### PR TITLE
結合ツールでフォルダが消えてしまう事故を防ぐため、PrepareOutputDirectoryの処理を暫定的に変更

### DIFF
--- a/src/MJS_WordPlugin_src/WordAddIn1/GenerateHTMLButton.CollectInfo.cs
+++ b/src/MJS_WordPlugin_src/WordAddIn1/GenerateHTMLButton.CollectInfo.cs
@@ -3,7 +3,10 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
+using DocumentFormat.OpenXml;
 using Microsoft.Office.Interop.Word;
+using OpenXmlPowerTools;
+using Table = Microsoft.Office.Interop.Word.Table;
 using Word = Microsoft.Office.Interop.Word;
 
 namespace WordAddIn1
@@ -67,7 +70,7 @@ namespace WordAddIn1
             // テーブル幅の自動調整
             foreach (Table wt in docCopy.Tables)
             {
-                if (wt.PreferredWidthType == Word.WdPreferredWidthType.wdPreferredWidthPoints)
+                if (wt.PreferredWidthType == WdPreferredWidthType.wdPreferredWidthPoints)
                     wt.AllowAutoFit = true;
             }
             
@@ -80,8 +83,14 @@ namespace WordAddIn1
             docCopy.WebOptions.Encoding = Microsoft.Office.Core.MsoEncoding.msoEncodingUTF8;
             
             // 一時HTMLとして保存
-            docCopy.SaveAs2(paths.tmpHtmlPath, WdSaveFormat.wdFormatFilteredHTML);
-            
+            //docCopy.SaveAs2(paths.tmpHtmlPath, WdSaveFormat.wdFormatFilteredHTML);
+
+            docCopy.SaveAs2(
+                paths.tmpHtmlPath,
+                WdSaveFormat.wdFormatFilteredHTML,
+                SaveNativePictureFormat: true
+            );
+
             // ドキュメントを閉じる
             docCopy.Close();
             

--- a/src/MJS_WordPlugin_src/WordAddIn1/GenerateHTMLButton.Helper.cs
+++ b/src/MJS_WordPlugin_src/WordAddIn1/GenerateHTMLButton.Helper.cs
@@ -52,24 +52,63 @@ namespace WordAddIn1
         }
 
         // 画像をコピーして一時フォルダを削除
+        //public void CopyAndDeleteTemporaryImages(string tmpFolder, string rootPath, string exportDir, StreamWriter log)
+        //{
+        //    if (Directory.Exists(tmpFolder))
+        //    {
+        //        try
+        //        {
+        //            // 一時フォルダ内のすべての画像ファイルをコピー
+        //            foreach (string pict in Directory.GetFiles(tmpFolder))
+        //            {
+        //                File.Copy(pict, Path.Combine(rootPath, exportDir, "pict", Path.GetFileName(pict)));
+        //            }
+
+        //            // 一時フォルダを削除
+        //            Directory.Delete(tmpFolder, true);
+        //        }
+        //        catch (Exception ex)
+        //        {
+        //            log.WriteLine($"画像フォルダのコピー中にエラーが発生しました: {ex.Message}");
+        //            throw;
+        //        }
+        //    }
+        //}
+
         public void CopyAndDeleteTemporaryImages(string tmpFolder, string rootPath, string exportDir, StreamWriter log)
         {
             if (Directory.Exists(tmpFolder))
             {
                 try
                 {
-                    // 一時フォルダ内のすべての画像ファイルをコピー
-                    foreach (string pict in Directory.GetFiles(tmpFolder))
+                    // pict フォルダのパス
+                    string pictFolder = Path.Combine(Path.GetDirectoryName(tmpFolder), "pict");
+                    // 既存の pict フォルダがあれば削除
+                    if (Directory.Exists(pictFolder))
                     {
-                        File.Copy(pict, Path.Combine(rootPath, exportDir, "pict", Path.GetFileName(pict)));
+                        Directory.Delete(pictFolder, true);
                     }
+                    // tmpFolder を pict にリネーム
+                    Directory.Move(tmpFolder, pictFolder);
 
-                    // 一時フォルダを削除
-                    Directory.Delete(tmpFolder, true);
+                    // pict を exportDir 配下に移動
+                    string exportPictDir = Path.Combine(rootPath, exportDir, "pict");
+                    // 既存の exportDir/pict があれば削除
+                    if (Directory.Exists(exportPictDir))
+                    {
+                        Directory.Delete(exportPictDir, true);
+                    }
+                    // exportDir がなければ作成
+                    string exportDirPath = Path.Combine(rootPath, exportDir);
+                    if (!Directory.Exists(exportDirPath))
+                    {
+                        Directory.CreateDirectory(exportDirPath);
+                    }
+                    Directory.Move(pictFolder, exportPictDir);
                 }
                 catch (Exception ex)
                 {
-                    log.WriteLine($"画像フォルダのコピー中にエラーが発生しました: {ex.Message}");
+                    log.WriteLine($"画像フォルダの移動中にエラーが発生しました: {ex.Message}");
                     throw;
                 }
             }

--- a/src/MJS_fileJoin_src/MJS_fileJoin/MainForm.BtnJoin.Helper.cs
+++ b/src/MJS_fileJoin_src/MJS_fileJoin/MainForm.BtnJoin.Helper.cs
@@ -1,15 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data;
 using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using System.Xml;
 
 namespace MJS_fileJoin
 {
     public partial class MainForm
     {
+        // 入力バリデーション
         private bool ValidateInput()
         {
             if (tbOutputDir.Text == "")
@@ -51,6 +54,102 @@ namespace MJS_fileJoin
                 }
             }
             return true;
+        }
+
+        // 出力ディレクトリを準備
+        //private void PrepareOutputDirectory()
+        //{
+        //    string outputPath = Path.Combine(tbOutputDir.Text, exportDir);
+
+        //    if (Directory.Exists(outputPath))
+        //    {
+        //        Directory.Delete(outputPath, true);
+        //    }
+
+        //    Directory.CreateDirectory(outputPath);
+
+        //    // 最初のHTMLフォルダの内容をコピー
+        //    CopyDirectory(lbHtmlList.Items[0].ToString(), outputPath);
+        //}
+
+        // 出力ディレクトリを準備
+        private void PrepareOutputDirectory()
+        {
+            // 新しいフォルダ名をタイムスタンプで生成（例: export_20240605_153045）
+            string newExportDir = "export_" + DateTime.Now.ToString("yyyyMMdd_HHmmss");
+            string outputPath = Path.Combine(tbOutputDir.Text, newExportDir);
+
+            // 新しいディレクトリを作成
+            Directory.CreateDirectory(outputPath);
+
+            // 最初のHTMLフォルダの内容をコピー
+            CopyDirectory(lbHtmlList.Items[0].ToString(), outputPath);
+
+            // exportDir変数を新しいフォルダ名に更新（他の処理で利用する場合）
+            exportDir = newExportDir;
+        }
+
+        // HTMLファイルリストの作成
+        private List<string> CreateHtmlFileList()
+        {
+            var htmlFiles = new List<string>();
+            foreach (string htmlDir in lbHtmlList.Items)
+            {
+                foreach (DataRow selRow in bookInfo[htmlDir].Select("Column1 = true"))
+                {
+                    htmlFiles.Add(selRow["Column4"].ToString() + ".html");
+                }
+            }
+            return htmlFiles;
+        }
+
+        // chbListOutputがチェックされている場合にjoinList.xmlを出力する
+        private void OutputJoinListXml()
+        {
+            if (!chbListOutput.Checked)
+                return;
+
+            XmlDocument list = new XmlDocument();
+            list.PreserveWhitespace = true;
+            list.LoadXml("<joinList></joinList>");
+            if (tbChangeTitle.Enabled)
+            {
+                list.DocumentElement.AppendChild(list.CreateWhitespace("\n\t"));
+                list.DocumentElement.AppendChild(list.CreateElement("changeTitle"));
+                list.DocumentElement.LastChild.InnerText = tbChangeTitle.Text;
+            }
+            if (tbAddTop.Enabled)
+            {
+                list.DocumentElement.AppendChild(list.CreateWhitespace("\n\t"));
+                list.DocumentElement.AppendChild(list.CreateElement("addTopLevel"));
+                list.DocumentElement.LastChild.InnerText = tbAddTop.Text;
+            }
+
+            list.DocumentElement.AppendChild(list.CreateWhitespace("\n\t"));
+            XmlNode htmllist = list.DocumentElement.AppendChild(list.CreateElement("htmlList"));
+
+            foreach (string htmlDir in lbHtmlList.Items)
+            {
+                htmllist.AppendChild(list.CreateWhitespace("\n\t\t"));
+                XmlNode htmlitem = htmllist.AppendChild(list.CreateElement("item"));
+                ((XmlElement)htmlitem).SetAttribute("src", htmlDir);
+
+                foreach (DataRow selRow in bookInfo[htmlDir].Select("Column1 = true"))
+                {
+                    htmlitem.AppendChild(list.CreateWhitespace("\n\t\t\t"));
+                    XmlNode checkedNode = htmlitem.AppendChild(list.CreateElement("checked"));
+                    ((XmlElement)checkedNode).SetAttribute("id", selRow["Column4"].ToString());
+                }
+                htmlitem.AppendChild(list.CreateWhitespace("\n\t\t"));
+            }
+            htmllist.AppendChild(list.CreateWhitespace("\n\t"));
+
+            list.DocumentElement.AppendChild(list.CreateWhitespace("\n\t"));
+            list.DocumentElement.AppendChild(list.CreateElement("outputDir"));
+            ((XmlElement)list.DocumentElement.LastChild).SetAttribute("src", tbOutputDir.Text);
+            list.DocumentElement.AppendChild(list.CreateWhitespace("\n"));
+
+            list.Save(Path.Combine(tbOutputDir.Text, "joinList.xml"));
         }
     }
 }

--- a/src/MJS_fileJoin_src/MJS_fileJoin/MainForm.BtnJoin.cs
+++ b/src/MJS_fileJoin_src/MJS_fileJoin/MainForm.BtnJoin.cs
@@ -59,14 +59,17 @@ namespace MJS_fileJoin
 
             //' Ver - 2023.16.08 - VyNL - ↑ - 追加'
 
-            if (Directory.Exists(tbOutputDir.Text + "\\" + exportDir))
-            {
-                Directory.Delete(tbOutputDir.Text + "\\" + exportDir, true);
-            }
+            // 出力ディレクトリの準備
+            PrepareOutputDirectory();
 
-            Directory.CreateDirectory(tbOutputDir.Text + "\\" + exportDir);
+            //if (Directory.Exists(tbOutputDir.Text + "\\" + exportDir))
+            //{
+            //    Directory.Delete(tbOutputDir.Text + "\\" + exportDir, true);
+            //}
 
-            CopyDirectory(lbHtmlList.Items[0].ToString(), tbOutputDir.Text + "\\" + exportDir);
+            //Directory.CreateDirectory(tbOutputDir.Text + "\\" + exportDir);
+
+            //CopyDirectory(lbHtmlList.Items[0].ToString(), tbOutputDir.Text + "\\" + exportDir);
 
             XmlDocument objToc = new XmlDocument();
             XmlNode objTocRoot = null;
@@ -79,10 +82,13 @@ namespace MJS_fileJoin
 
             //各webHelpフォルダ処理
 
-            List<string> lsfiles = new List<string>();
-            foreach (string htmlDir in lbHtmlList.Items)
-                foreach (DataRow selRow in bookInfo[htmlDir].Select("Column1 = true"))
-                    lsfiles.Add(selRow["Column4"].ToString() + ".html");
+            // HTMLファイルリストの作成
+            List<string> lsfiles = CreateHtmlFileList();
+
+            //List<string> lsfiles = new List<string>();
+            //foreach (string htmlDir in lbHtmlList.Items)
+            //    foreach (DataRow selRow in bookInfo[htmlDir].Select("Column1 = true"))
+            //        lsfiles.Add(selRow["Column4"].ToString() + ".html");
 
             int picCount = 0;
             foreach (string htmlDir in lbHtmlList.Items)
@@ -460,50 +466,53 @@ namespace MJS_fileJoin
             //目次出力
             createToc(objToc.DocumentElement);
 
-            if (chbListOutput.Checked)
-            {
-                XmlDocument list = new XmlDocument();
-                list.PreserveWhitespace = true;
-                list.LoadXml("<joinList></joinList>");
-                if (tbChangeTitle.Enabled)
-                {
-                    list.DocumentElement.AppendChild(list.CreateWhitespace("\n\t"));
-                    list.DocumentElement.AppendChild(list.CreateElement("changeTitle"));
-                    list.DocumentElement.LastChild.InnerText = tbChangeTitle.Text;
-                }
-                if (tbAddTop.Enabled)
-                {
-                    list.DocumentElement.AppendChild(list.CreateWhitespace("\n\t"));
-                    list.DocumentElement.AppendChild(list.CreateElement("addTopLevel"));
-                    list.DocumentElement.LastChild.InnerText = tbAddTop.Text;
-                }
+            // chbListOutputがチェックされている場合にjoinList.xmlを出力する
+            OutputJoinListXml();
 
-                list.DocumentElement.AppendChild(list.CreateWhitespace("\n\t"));
-                XmlNode htmllist = list.DocumentElement.AppendChild(list.CreateElement("htmlList"));
+            //if (chbListOutput.Checked)
+            //{
+            //    XmlDocument list = new XmlDocument();
+            //    list.PreserveWhitespace = true;
+            //    list.LoadXml("<joinList></joinList>");
+            //    if (tbChangeTitle.Enabled)
+            //    {
+            //        list.DocumentElement.AppendChild(list.CreateWhitespace("\n\t"));
+            //        list.DocumentElement.AppendChild(list.CreateElement("changeTitle"));
+            //        list.DocumentElement.LastChild.InnerText = tbChangeTitle.Text;
+            //    }
+            //    if (tbAddTop.Enabled)
+            //    {
+            //        list.DocumentElement.AppendChild(list.CreateWhitespace("\n\t"));
+            //        list.DocumentElement.AppendChild(list.CreateElement("addTopLevel"));
+            //        list.DocumentElement.LastChild.InnerText = tbAddTop.Text;
+            //    }
 
-                foreach (string htmlDir in lbHtmlList.Items)
-                {
-                    htmllist.AppendChild(list.CreateWhitespace("\n\t\t"));
-                    XmlNode htmlitem = htmllist.AppendChild(list.CreateElement("item"));
-                    ((XmlElement)htmlitem).SetAttribute("src", htmlDir);
+            //    list.DocumentElement.AppendChild(list.CreateWhitespace("\n\t"));
+            //    XmlNode htmllist = list.DocumentElement.AppendChild(list.CreateElement("htmlList"));
 
-                    foreach (DataRow selRow in bookInfo[htmlDir].Select("Column1 = true"))
-                    {
-                        htmlitem.AppendChild(list.CreateWhitespace("\n\t\t\t"));
-                        XmlNode checkedNode = htmlitem.AppendChild(list.CreateElement("checked"));
-                        ((XmlElement)checkedNode).SetAttribute("id", selRow["Column4"].ToString());
-                    }
-                    htmlitem.AppendChild(list.CreateWhitespace("\n\t\t"));
-                }
-                htmllist.AppendChild(list.CreateWhitespace("\n\t"));
+            //    foreach (string htmlDir in lbHtmlList.Items)
+            //    {
+            //        htmllist.AppendChild(list.CreateWhitespace("\n\t\t"));
+            //        XmlNode htmlitem = htmllist.AppendChild(list.CreateElement("item"));
+            //        ((XmlElement)htmlitem).SetAttribute("src", htmlDir);
 
-                list.DocumentElement.AppendChild(list.CreateWhitespace("\n\t"));
-                list.DocumentElement.AppendChild(list.CreateElement("outputDir"));
-                ((XmlElement)list.DocumentElement.LastChild).SetAttribute("src", tbOutputDir.Text);
-                list.DocumentElement.AppendChild(list.CreateWhitespace("\n"));
+            //        foreach (DataRow selRow in bookInfo[htmlDir].Select("Column1 = true"))
+            //        {
+            //            htmlitem.AppendChild(list.CreateWhitespace("\n\t\t\t"));
+            //            XmlNode checkedNode = htmlitem.AppendChild(list.CreateElement("checked"));
+            //            ((XmlElement)checkedNode).SetAttribute("id", selRow["Column4"].ToString());
+            //        }
+            //        htmlitem.AppendChild(list.CreateWhitespace("\n\t\t"));
+            //    }
+            //    htmllist.AppendChild(list.CreateWhitespace("\n\t"));
 
-                list.Save(Path.Combine(tbOutputDir.Text, "joinList.xml"));
-            }
+            //    list.DocumentElement.AppendChild(list.CreateWhitespace("\n\t"));
+            //    list.DocumentElement.AppendChild(list.CreateElement("outputDir"));
+            //    ((XmlElement)list.DocumentElement.LastChild).SetAttribute("src", tbOutputDir.Text);
+            //    list.DocumentElement.AppendChild(list.CreateWhitespace("\n"));
+
+            //    list.Save(Path.Combine(tbOutputDir.Text, "joinList.xml"));
+            //}
 
             //書誌情報ファイルのマージ
             mergeHeaderFile();


### PR DESCRIPTION
MJSプラグインにおいて、画像フォルダをpictフォルダにコピーする処理があったので、軽量化を図るためにフォルダを移動する処理に変更（まだテスト段階）。