### PR TITLE
RemoveSearchBlockByTitleメソッドを修正

### DIFF
--- a/src/MJS_WordPlugin_src/WordAddIn1/GenerateHTMLButton.RemoveSearchBlock.cs
+++ b/src/MJS_WordPlugin_src/WordAddIn1/GenerateHTMLButton.RemoveSearchBlock.cs
@@ -1,5 +1,6 @@
 ﻿// GenerateHTMLButton.RemoveSearchBlock.cs
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -29,14 +30,21 @@ namespace WordAddIn1
 
             foreach (Match match in matches)
             {
-                // 改行・空白・全角半角を除去して比較
-                string titleInner = match.Groups[1].Value.Trim()
-                    .Replace("\r", "").Replace("\n", "").Replace("　", " ").Normalize();
+                // HTMLエスケープを解除してから正規化
+                string titleInner = System.Net.WebUtility.HtmlDecode(match.Groups[1].Value.Trim())
+                    .Replace("\r", "").Replace("\n", "").Replace("　", " ")
+                    .Replace("&amp;", "&").Replace("&lt;", "<").Replace("&gt;", ">")
+                    .Replace("&quot;", "\"").Replace("&#39;", "'")
+                    .Normalize();
 
-                string searchTitleNormalized = searchTitleText.Trim()
-                    .Replace("\r", "").Replace("\n", "").Replace("　", " ").Normalize();
+                string searchTitleNormalized = System.Net.WebUtility.HtmlDecode(searchTitleText.Trim())
+                    .Replace("\r", "").Replace("\n", "").Replace("　", " ")
+                    .Replace("&amp;", "&").Replace("&lt;", "<").Replace("&gt;", ">")
+                    .Replace("&quot;", "\"").Replace("&#39;", "'")
+                    .Normalize();
 
-                if (titleInner == searchTitleNormalized)
+                // 大文字小文字を無視して比較
+                if (string.Equals(titleInner, searchTitleNormalized, StringComparison.OrdinalIgnoreCase))
                 {
                     content = content.Replace(match.Value, "");
                 }

--- a/src/MJS_fileJoin_src/MJS_fileJoin/MainForm.BtnJoin.RemoveSearchBlock.cs
+++ b/src/MJS_fileJoin_src/MJS_fileJoin/MainForm.BtnJoin.RemoveSearchBlock.cs
@@ -26,14 +26,21 @@ namespace MJS_fileJoin
 
             foreach (Match match in matches)
             {
-                // 改行・空白・全角半角を除去して比較
-                string titleInner = match.Groups[1].Value.Trim()
-                    .Replace("\r", "").Replace("\n", "").Replace("　", " ").Normalize();
+                // HTMLエスケープを解除してから正規化
+                string titleInner = System.Net.WebUtility.HtmlDecode(match.Groups[1].Value.Trim())
+                    .Replace("\r", "").Replace("\n", "").Replace("　", " ")
+                    .Replace("&amp;", "&").Replace("&lt;", "<").Replace("&gt;", ">")
+                    .Replace("&quot;", "\"").Replace("&#39;", "'")
+                    .Normalize();
 
-                string searchTitleNormalized = searchTitleText.Trim()
-                    .Replace("\r", "").Replace("\n", "").Replace("　", " ").Normalize();
+                string searchTitleNormalized = System.Net.WebUtility.HtmlDecode(searchTitleText.Trim())
+                    .Replace("\r", "").Replace("\n", "").Replace("　", " ")
+                    .Replace("&amp;", "&").Replace("&lt;", "<").Replace("&gt;", ">")
+                    .Replace("&quot;", "\"").Replace("&#39;", "'")
+                    .Normalize();
 
-                if (titleInner == searchTitleNormalized)
+                // 大文字小文字を無視して比較
+                if (string.Equals(titleInner, searchTitleNormalized, StringComparison.OrdinalIgnoreCase))
                 {
                     content = content.Replace(match.Value, "");
                 }

--- a/src/MJS_fileJoin_src/MJS_fileJoin/MainForm.LinkCheck.AddLink.cs
+++ b/src/MJS_fileJoin_src/MJS_fileJoin/MainForm.LinkCheck.AddLink.cs
@@ -38,6 +38,7 @@ namespace MJS_fileJoin
         }
 
         // 表示用のタイトルデコードメソッド（HTMLエンティティをデコードするが、HTMLタグは保持）
+        
         private string DecodeForDisplay(string title)
         {
             if (string.IsNullOrEmpty(title))
@@ -56,6 +57,9 @@ namespace MJS_fileJoin
             bool isMatch = normalizedTitleName == normalizedLinkText;
 
             // 表示用にHTMLエンティティをデコード
+            // • &lt; → <
+            // • &gt; → >
+            // • &amp; → &
             string displayLinkText = DecodeForDisplay(m.Groups[2].Value);
             string displayTitleName = DecodeForDisplay(titleName);
 


### PR DESCRIPTION
- HTMLエスケープを解除してから正規化
- 大文字小文字を無視して比較 結合によって、目次およびパンくず内の特殊文字がエンコードされてしまう問題を修正